### PR TITLE
fix: release json minification

### DIFF
--- a/esp_provisioning/example/android/app/build.gradle
+++ b/esp_provisioning/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdk flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/esp_provisioning/example/pubspec.yaml
+++ b/esp_provisioning/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esp_provisioning_example
 description: Demonstrates how to use the esp_provisioning plugin.
-version: 1.0.0
+version: 1.0.2
 publish_to: none
 
 environment:

--- a/esp_provisioning/pubspec.yaml
+++ b/esp_provisioning/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esp_provisioning
 description: SpinDance Flutter federated plugin; wraps Espressif's native mobile provisioning libraries.
-version: 1.0.0
+version: 1.0.2
 publish_to: none
 
 environment:

--- a/esp_provisioning_android/android/build.gradle
+++ b/esp_provisioning_android/android/build.gradle
@@ -43,6 +43,13 @@ android {
     defaultConfig {
         minSdkVersion 24
     }
+
+    buildTypes {
+        release {
+            minifyEnabled true
+            consumerProguardFiles 'proguard-rules.pro'
+        }
+    }
 }
 
 dependencies {

--- a/esp_provisioning_android/android/build.gradle
+++ b/esp_provisioning_android/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdk 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/esp_provisioning_android/android/proguard-rules.pro
+++ b/esp_provisioning_android/android/proguard-rules.pro
@@ -1,0 +1,5 @@
+-keepclassmembers,allowobfuscation class * {
+ @com.google.gson.annotations.SerializedName <fields>;
+}
+
+-keep class com.spindance.esp_provisioning.model.** { *; }

--- a/esp_provisioning_android/android/proguard-rules.pro
+++ b/esp_provisioning_android/android/proguard-rules.pro
@@ -3,3 +3,13 @@
 }
 
 -keep class com.spindance.esp_provisioning.model.** { *; }
+-dontwarn com.espressif.provisioning.**
+-dontwarn espressif.**
+-keep class com.espressif.provisioning.** {*;}
+-keepclassmembers class com.espressif.provisioning.** {*;}
+-keep class espressif.** {*;}
+-keepclassmembers class espressif.** {*;}
+-keep interface com.espressif.provisioning.** {*;}
+-keep interface espressif.** {*;}
+-keep public enum com.espressif.provisioning.** {*;}
+-keep public enum espressif.** {*;}

--- a/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/EspProvisioningPlugin.kt
+++ b/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/EspProvisioningPlugin.kt
@@ -10,6 +10,9 @@ import com.espressif.provisioning.ESPConstants
 import com.espressif.provisioning.ESPDevice
 import com.espressif.provisioning.ESPProvisionManager
 import com.google.gson.Gson
+import com.spindance.esp_provisioning.model.EspBleDevice
+import com.spindance.esp_provisioning.model.EspException
+import com.spindance.esp_provisioning.model.ScannedPeripheral
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
@@ -140,7 +143,7 @@ class EspProvisioningPlugin : FlutterPlugin, MethodCallHandler {
             scannedDevices = deviceMap
 
             // Convert the deviceMap to a list of EspBleDevice converted to JSON strings.
-            val devices = deviceMap.values.map { EspBleDevice(it.device.name, it.scanResult.rssi)}.toList()
+            val devices = deviceMap.values.map { EspBleDevice(it.device.name, it.scanResult.rssi) }.toList()
             val devicesJson = devices.map { Gson().toJson(it).toString() }
             resultCallback.success(devicesJson)
           }

--- a/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/ScanNetworksListener.kt
+++ b/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/ScanNetworksListener.kt
@@ -3,6 +3,8 @@ package com.spindance.esp_provisioning
 import android.util.Log
 import com.espressif.provisioning.WiFiAccessPoint
 import com.espressif.provisioning.listeners.WiFiScanListener
+import com.spindance.esp_provisioning.model.AccessPoint
+import com.spindance.esp_provisioning.model.EspException
 import java.lang.Exception
 import java.util.ArrayList
 

--- a/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/SdkBleScanListener.kt
+++ b/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/SdkBleScanListener.kt
@@ -5,6 +5,8 @@ import android.bluetooth.BluetoothDevice
 import android.bluetooth.le.ScanResult
 import android.util.Log
 import com.espressif.provisioning.listeners.BleScanListener
+import com.spindance.esp_provisioning.model.EspException
+import com.spindance.esp_provisioning.model.ScannedPeripheral
 
 class SdkBleScanListener(
   private val completionCallback: (Result<Map<String, ScannedPeripheral>>) -> Unit

--- a/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/SdkProvisionListener.kt
+++ b/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/SdkProvisionListener.kt
@@ -3,6 +3,7 @@ package com.spindance.esp_provisioning
 import android.util.Log
 import com.espressif.provisioning.ESPConstants
 import com.espressif.provisioning.listeners.ProvisionListener
+import com.spindance.esp_provisioning.model.EspException
 import kotlin.Exception
 
 class SdkProvisionListener(

--- a/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/SendDataListener.kt
+++ b/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/SendDataListener.kt
@@ -2,6 +2,7 @@ package com.spindance.esp_provisioning
 
 import android.util.Log
 import com.espressif.provisioning.listeners.ResponseListener
+import com.spindance.esp_provisioning.model.EspException
 import kotlin.Exception
 
 class SendDataListener(

--- a/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/AccessPoint.kt
+++ b/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/AccessPoint.kt
@@ -1,4 +1,4 @@
-package com.spindance.esp_provisioning
+package com.spindance.esp_provisioning.model
 
 import com.espressif.provisioning.WiFiAccessPoint
 //import kotlinx.serialization.Serializable

--- a/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/AccessPoint.kt
+++ b/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/AccessPoint.kt
@@ -1,9 +1,7 @@
 package com.spindance.esp_provisioning.model
 
 import com.espressif.provisioning.WiFiAccessPoint
-//import kotlinx.serialization.Serializable
 
-//@Serializable
 data class AccessPoint(
   val ssid: String,
   val channel: UInt,

--- a/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/AccessPointSecurity.kt
+++ b/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/AccessPointSecurity.kt
@@ -1,8 +1,5 @@
 package com.spindance.esp_provisioning.model
 
-//import kotlinx.serialization.Serializable
-
-//@Serializable
 enum class AccessPointSecurity(val value: Int) {
   OPEN(0),
   WEP(1),

--- a/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/AccessPointSecurity.kt
+++ b/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/AccessPointSecurity.kt
@@ -1,4 +1,4 @@
-package com.spindance.esp_provisioning
+package com.spindance.esp_provisioning.model
 
 //import kotlinx.serialization.Serializable
 

--- a/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/EspBleDevice.kt
+++ b/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/EspBleDevice.kt
@@ -1,3 +1,3 @@
-package com.spindance.esp_provisioning
+package com.spindance.esp_provisioning.model
 
 data class EspBleDevice(val name: String, val rssi: Int)

--- a/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/EspException.kt
+++ b/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/EspException.kt
@@ -1,4 +1,4 @@
-package com.spindance.esp_provisioning
+package com.spindance.esp_provisioning.model
 
 sealed class EspException(val errorCodeString: String) : Exception(errorCodeString) {
   data object ScanStartFailed: EspException("ScanStartFailed")

--- a/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/ScannedPeripheral.kt
+++ b/esp_provisioning_android/android/src/main/kotlin/com/spindance/esp_provisioning/model/ScannedPeripheral.kt
@@ -1,4 +1,4 @@
-package com.spindance.esp_provisioning
+package com.spindance.esp_provisioning.model
 
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.le.ScanRecord

--- a/esp_provisioning_android/pubspec.yaml
+++ b/esp_provisioning_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esp_provisioning_android
 description: Android implementation of the esp_provisioning plugin
-version: 1.0.0
+version: 1.0.2
 publish_to: none
 
 environment:

--- a/esp_provisioning_ios/pubspec.yaml
+++ b/esp_provisioning_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esp_provisioning_ios
 description: iOS implementation of the esp_provisioning plugin
-version: 1.0.0
+version: 1.0.2
 publish_to: none
 
 environment:

--- a/esp_provisioning_platform_interface/pubspec.yaml
+++ b/esp_provisioning_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esp_provisioning_platform_interface
 description: A common platform interface for the esp_provisioning plugin.
-version: 1.0.0
+version: 1.0.2
 publish_to: none
 
 environment:


### PR DESCRIPTION
# Motivation for Change

Callbox Flutter Android release build BLE scan fails, presumably due to minification of serialized classes in this plugin

# Description of Change

Moved all model classes into new package, attempted to skip minification for those files via proguard rules.

## Types of changes

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Related stories

none

# How has this been tested?

Pointed CallBox Flutter at this branch and created a release build and tested BLE scan.

# Checklist

- [x] I have performed a self-review of my code.
- [NA] If applicable, I have made necessary corresponding changes to the README.
- [NA] I have added tests that prove my fix is effective or that my feature works.
- [NA] If applicable, I have added screenshots or videos showing the example app UI changes I made.
- [x] `./format-and-analyze.sh` succeeds.
- [x] Unit tests for all packages succeed.
