### PR TITLE
feat: freezed downgrade

### DIFF
--- a/esp_provisioning/example/pubspec.yaml
+++ b/esp_provisioning/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esp_provisioning_example
 description: Demonstrates how to use the esp_provisioning plugin.
-version: 1.0.3
+version: 1.0.4
 publish_to: none
 
 environment:

--- a/esp_provisioning/pubspec.yaml
+++ b/esp_provisioning/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esp_provisioning
 description: SpinDance Flutter federated plugin; wraps Espressif's native mobile provisioning libraries.
-version: 1.0.3
+version: 1.0.4
 publish_to: none
 
 environment:

--- a/esp_provisioning/pubspec.yaml
+++ b/esp_provisioning/pubspec.yaml
@@ -32,8 +32,8 @@ dev_dependencies:
   fake_async: ^1.3.1
   flutter_test:
     sdk: flutter
-  freezed: ^3.0.0-0.0.dev
-  json_serializable: ^6.9.3
+  freezed: ^2.5.7
+  json_serializable: ^6.9.0
   mocktail: ^1.0.3
   plugin_platform_interface: ^2.1.8
   very_good_analysis: ^7.0.0

--- a/esp_provisioning_android/pubspec.yaml
+++ b/esp_provisioning_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esp_provisioning_android
 description: Android implementation of the esp_provisioning plugin
-version: 1.0.3
+version: 1.0.4
 publish_to: none
 
 environment:

--- a/esp_provisioning_ios/pubspec.yaml
+++ b/esp_provisioning_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esp_provisioning_ios
 description: iOS implementation of the esp_provisioning plugin
-version: 1.0.3
+version: 1.0.4
 publish_to: none
 
 environment:

--- a/esp_provisioning_platform_interface/pubspec.yaml
+++ b/esp_provisioning_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esp_provisioning_platform_interface
 description: A common platform interface for the esp_provisioning plugin.
-version: 1.0.3
+version: 1.0.4
 publish_to: none
 
 environment:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Pull Request Title above -->

# Motivation for Change

Need a version of this package that is compatible with CallBox.

# Description of Change

Downgraded freezed to non-dev build, which required downgrading json_serializable to 6.9.0. Could not use later versions of those packages because CallBox requires graphql_codegen which is not compatible with them because it requires older version of dart_style.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Related stories

none

# How has this been tested?

Ran app on iOS and Android

# Checklist

- [x] I have performed a self-review of my code.
- [NA] If applicable, I have made necessary corresponding changes to the README.
- [NA] I have added tests that prove my fix is effective or that my feature works.
- [NA] If applicable, I have added screenshots or videos showing the example app UI changes I made.
- [x] `./format-and-analyze.sh` succeeds.
- [x] Unit tests for all packages succeed.
